### PR TITLE
[fix]ISUCON本に載っているクエリに変更

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -6,7 +6,7 @@ set -e
 echo
 echo '## alp'
 echo '```'
-sudo alp json --file /var/log/nginx/access.log -m "/image/[0-9a-zA-Z]+,/posts/[0-9a-zA-Z]+" --sort avg -r
+sudo alp json --file /var/log/nginx/access.log -m "/image/[0-9a-zA-Z]+,/posts/[0-9a-zA-Z]+,/@[0-9a-zA-Z]+" --sort avg -r
 echo '```'
 
 # pt-query-digest で解析

--- a/golang/app.go
+++ b/golang/app.go
@@ -47,6 +47,7 @@ type User struct {
 type Post struct {
 	ID           int       `db:"id"`
 	UserID       int       `db:"user_id"`
+	AccountName  string    `db:"account_name"`
 	Imgdata      []byte    `db:"imgdata"`
 	Body         string    `db:"body"`
 	Mime         string    `db:"mime"`
@@ -386,7 +387,7 @@ func getIndex(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err := db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC")
+	err := db.Select(&results, "SELECT p.id, p.user_id, p.body, p.created_at, p.mime, u.account_name FROM `posts` AS p JOIN `users` AS u ON (p.user_id=u.id) WHERE u.del_flg=0 ORDER BY p.created_at DESC LIMIT 20")
 	if err != nil {
 		log.Print(err)
 		return


### PR DESCRIPTION
## score
{"pass":true,"score":31788,"success":30069,"fail":0,"messages":[]}

## top
```
op - 19:49:33 up 17 min,  1 user,  load average: 2.15, 0.73, 0.44
Tasks: 113 total,   3 running, 110 sleeping,   0 stopped,   0 zombie
%Cpu(s): 62.2 us, 28.5 sy,  0.0 ni,  0.0 id,  0.2 wa,  0.0 hi,  9.2 si,  0.0 st
MiB Mem :   3827.7 total,   1654.9 free,    821.2 used,   1351.6 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.   2767.9 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
   7700 mysql     20   0 1809256 633260  36992 S  87.0  16.2   0:13.52 mysqld
   7219 isucon    20   0 1234352  31024   7040 R  65.8   0.8   0:09.03 app
   7487 www-data  20   0   56484   6580   4224 S  20.9   0.2   0:02.38 nginx
   7486 www-data  20   0   56124   6476   4224 S   5.3   0.2   0:00.56 nginx
     13 root      20   0       0      0      0 S   0.3   0.0   0:00.23 ksoftirqd/0
     14 root      20   0       0      0      0 I   0.3   0.0   0:00.20 rcu_sched
     22 root      20   0       0      0      0 S   0.3   0.0   0:00.20 ksoftirqd/1
     35 root      20   0       0      0      0 I   0.3   0.0   0:00.08 kworker/u4:2-writeback
      1 root      20   0  100828  11392   8320 S   0.0   0.3   0:02.81 systemd
      2 root      20   0       0      0      0 S   0.0   0.0   0:00.00 kthreadd
      3 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 rcu_gp
      4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 rcu_par_gp
      5 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 slub_flushwq
      6 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 netns
      7 root      20   0       0      0      0 I   0.0   0.0   0:00.02 kworker/0:0-events
      8 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker/0:0H-events_highpri
      9 root      20   0       0      0      0 I   0.0   0.0   0:00.18 kworker/u4:0-events_unbound
     10 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 mm_percpu_wq
```

## alp
```
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
| COUNT | 1XX |  2XX  | 3XX | 4XX | 5XX | METHOD |         URI         |  MIN  |  MAX  |   SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY) |  MAX(BODY)  |   SUM(BODY)    | AVG(BODY)  |
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
|   200 |   0 |   200 |   0 |   0 |   0 | GET    | /posts              | 0.060 | 0.640 |  84.110 | 0.421 | 0.516 | 0.544 | 0.576 |  0.109 |  4965.000 |    5795.000 |    1070133.000 |   5350.665 |
|     1 |   0 |     1 |   0 |   0 |   0 | GET    | /initialize         | 0.356 | 0.356 |   0.356 | 0.356 | 0.356 | 0.356 | 0.356 |  0.000 |     0.000 |       0.000 |          0.000 |      0.000 |
|   200 |   0 |   200 |   0 |   0 |   0 | GET    | /@[0-9a-zA-Z]+      | 0.152 | 0.596 |  67.750 | 0.339 | 0.432 | 0.464 | 0.528 |  0.078 |  1542.000 |    4741.000 |     656276.000 |   3281.380 |
|  1042 |   0 |  1042 |   0 |   0 |   0 | GET    | /                   | 0.024 | 0.420 | 211.456 | 0.203 | 0.272 | 0.296 | 0.340 |  0.053 |  2615.000 |    6041.000 |    3371074.000 |   3235.196 |
|   110 |   0 |     0 | 110 |   0 |   0 | POST   | /register           | 0.016 | 0.140 |   7.248 | 0.066 | 0.096 | 0.108 | 0.136 |  0.026 |     0.000 |       0.000 |          0.000 |      0.000 |
|   757 |   0 |     0 | 757 |   0 |   0 | POST   | /login              | 0.028 | 0.168 |  35.620 | 0.047 | 0.084 | 0.100 | 0.124 |  0.029 |     0.000 |       0.000 |          0.000 |      0.000 |
|   180 |   0 |     0 |  90 |  90 |   0 | POST   | /                   | 0.004 | 0.212 |   8.316 | 0.046 | 0.128 | 0.152 | 0.204 |  0.051 |     0.000 |       0.000 |          0.000 |      0.000 |
|  1318 |   0 |  1318 |   0 |   0 |   0 | GET    | /posts/[0-9a-zA-Z]+ | 0.004 | 0.164 |  57.621 | 0.044 | 0.076 | 0.088 | 0.116 |  0.024 |   706.000 |    1884.000 |    1703583.000 |   1292.552 |
|    92 |   0 |     0 |  92 |   0 |   0 | POST   | /comment            | 0.004 | 0.068 |   1.896 | 0.021 | 0.032 | 0.048 | 0.068 |  0.012 |     0.000 |       0.000 |          0.000 |      0.000 |
| 17362 |   0 | 17362 |   0 |   0 |   0 | GET    | /image/[0-9a-zA-Z]+ | 0.000 | 0.180 | 150.953 | 0.009 | 0.020 | 0.024 | 0.036 |  0.008 | 34446.000 | 1090821.000 | 5822153717.000 | 335338.885 |
|   110 |   0 |     0 |   0 | 110 |   0 | GET    | /admin/banned       | 0.004 | 0.052 |   0.932 | 0.008 | 0.016 | 0.032 | 0.052 |  0.010 |     0.000 |       0.000 |          0.000 |      0.000 |
|   250 |   0 |   250 |   0 |   0 |   0 | GET    | /login              | 0.004 | 0.032 |   0.832 | 0.003 | 0.008 | 0.012 | 0.024 |  0.004 |   615.000 |     615.000 |     153750.000 |    615.000 |
|   125 |   0 |     0 | 125 |   0 |   0 | GET    | /logout             | 0.000 | 0.020 |   0.288 | 0.002 | 0.008 | 0.008 | 0.012 |  0.003 |    24.000 |      24.000 |       3000.000 |     24.000 |
|  1794 |   0 |  1794 |   0 |   0 |   0 | GET    | /js/timeago.min.js  | 0.000 | 0.068 |   2.800 | 0.002 | 0.004 | 0.008 | 0.016 |  0.003 |  1915.000 |    1915.000 |    3435510.000 |   1915.000 |
|  1794 |   0 |  1794 |   0 |   0 |   0 | GET    | /favicon.ico        | 0.000 | 0.028 |   2.768 | 0.002 | 0.004 | 0.008 | 0.012 |  0.003 |    43.000 |      43.000 |      77142.000 |     43.000 |
|  1794 |   0 |  1794 |   0 |   0 |   0 | GET    | /css/style.css      | 0.000 | 0.040 |   2.412 | 0.001 | 0.004 | 0.004 | 0.012 |  0.003 |  1549.000 |    1549.000 |    2778906.000 |   1549.000 |
|  1794 |   0 |  1794 |   0 |   0 |   0 | GET    | /js/main.js         | 0.000 | 0.024 |   2.276 | 0.001 | 0.004 | 0.004 | 0.012 |  0.003 |  1824.000 |    1824.000 |    3272256.000 |   1824.000 |
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
```

## pt-query-digest
```

# 23.6s user time, 40ms system time, 52.03M rss, 58.37M vsz
# Current date: Thu Nov  2 19:45:40 2023
# Hostname: ip-192-168-1-10
# Files: /var/log/mysql/mysql-slow.log
# Overall: 451.50k total, 32 unique, 7.17k QPS, 1.71x concurrency ________
# Time range: 2023-11-02T10:37:31 to 2023-11-02T10:38:34
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time           108s     1us   320ms   238us   541us     3ms    42us
# Lock time          355ms       0     7ms       0     1us    25us       0
# Rows sent          2.06M       0   9.76k    4.78    0.99  201.02       0
# Rows examine      25.17M       0  97.75k   58.46    0.99   2.07k       0
# Query size        67.62M      17   1.26M  157.05   80.10  10.33k   31.70

# Profile
# Rank Query ID                     Response time Calls  R/Call V/M   Item
# ==== ============================ ============= ====== ====== ===== ====
#    1 0xDA556F9115773A1A99AA016... 17.2338 16.0% 146083 0.0001  0.00 ADMIN PREPARE
#    2 0x19759A5557089FD5B718D44... 16.9831 15.8%  18680 0.0009  0.00 SELECT posts
#    3 0xCDEB1AFF2AE2BE51B2ED5CF... 16.3599 15.2%    200 0.0818  0.01 SELECT comments
#    4 0x7A12D0C8F433684C3027353... 13.5527 12.6%    200 0.0678  0.01 SELECT posts
#    5 0x396201721CD58410E070DA9... 12.7242 11.8%  68394 0.0002  0.00 SELECT users
#    6 0x624863D30DAC59FA1684928...  7.5955  7.0%  27007 0.0003  0.00 SELECT comments
#    7 0x422390B42D4DD86C7539A5F...  6.3420  5.9%  28325 0.0002  0.00 SELECT comments
#    8 0xE83DA93257C7B787C67B1B0...  5.1308  4.8%    200 0.0257  0.01 SELECT posts
#    9 0x009A61E5EFBD5A5E4097914...  4.2833  4.0%     82 0.0522  0.03 INSERT posts
#   10 0xC9383ACA6FF14C29E819735...  1.8249  1.7%    200 0.0091  0.01 SELECT posts
#   11 0x07890000813C4CC7111FD2D...  0.9763  0.9% 146080 0.0000  0.00 ADMIN CLOSE STMT
# MISC 0xMISC                        4.7694  4.4%  16048 0.0003   0.0 <21 ITEMS>

# Query 1: 2.36k QPS, 0.28x concurrency, ID 0xDA556F9115773A1A99AA0165670CE848 at byte 6666029
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         32  146083
# Exec time     15     17s    17us   164ms   117us   348us   715us    44us
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     6   4.18M      30      30      30      30       0      30
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ########
#   1ms  #
#  10ms  #
# 100ms  #
#    1s
#  10s+
administrator command: Prepare\G

# Query 2: 301.29 QPS, 0.27x concurrency, ID 0x19759A5557089FD5B718D440CBBB5C55 at byte 128658773
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          4   18680
# Exec time     15     17s    80us    40ms   909us     4ms     2ms   236us
# Lock time     13    47ms       0     3ms     2us     1us    44us     1us
# Rows sent      0  18.24k       1       1       1       1       0       1
# Rows examine   0  18.24k       1       1       1       1       0       1
# Query size     1 720.80k      37      40   39.51   38.53    0.23   38.53
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  #
# 100us  ################################################################
#   1ms  ################
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `posts` WHERE `id` = 10352\G

# Query 3: 3.28 QPS, 0.27x concurrency, ID 0xCDEB1AFF2AE2BE51B2ED5CF03D4E749F at byte 57942935
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:33
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     200
# Exec time     15     16s    33ms   192ms    82ms   134ms    29ms    75ms
# Lock time      0     2ms       0     2ms    12us     1us   143us     1us
# Rows sent      0     200       1       1       1       1       0       1
# Rows examine  75  19.08M  97.66k  97.75k  97.70k  97.04k       0  97.04k
# Query size     0  12.09k      61      62   61.92   59.77       0   59.77
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms  #########################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 844\G

# Query 4: 3.28 QPS, 0.22x concurrency, ID 0x7A12D0C8F433684C3027353C36CAB572 at byte 17898780
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2023-11-02T10:37:33 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     200
# Exec time     12     14s    32ms   203ms    68ms   105ms    26ms    61ms
# Lock time      0   272us       0     9us     1us     1us       0     1us
# Rows sent     91   1.89M   9.57k   9.76k   9.66k   9.33k       0   9.33k
# Rows examine   7   1.89M   9.57k   9.76k   9.66k   9.33k       0   9.33k
# Query size     0  27.73k     142     142     142     142       0     142
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms  #######
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= '2016-01-02T11:43:30+09:00' ORDER BY `created_at` DESC\G

# Query 5: 1.10k QPS, 0.21x concurrency, ID 0x396201721CD58410E070DA9421CA8C8D at byte 117780508
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         15   68394
# Exec time     11     13s    30us    32ms   186us   626us   551us    66us
# Lock time     45   160ms       0     5ms     2us     1us    43us     1us
# Rows sent      3  66.79k       1       1       1       1       0       1
# Rows examine   0  66.79k       1       1       1       1       0       1
# Query size     3   2.47M      36      39   37.89   36.69    0.16   36.69
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ################
#   1ms  ##
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'users'\G
#    SHOW CREATE TABLE `isuconp`.`users`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `users` WHERE `id` = 129\G

# Query 6: 435.60 QPS, 0.12x concurrency, ID 0x624863D30DAC59FA16849282195BE09F at byte 35242097
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          5   27007
# Exec time      7      8s    52us    28ms   281us     1ms   694us   108us
# Lock time     16    57ms       0     3ms     2us     1us    30us     1us
# Rows sent      1  25.83k       0       3    0.98    2.90    1.34       0
# Rows examine   0 110.01k       0      26    4.17   15.25    6.12       0
# Query size     3   2.13M      79      83   82.68   80.10    0.12   80.10
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ############################################
# 100us  ################################################################
#   1ms  ######
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `comments` WHERE `post_id` = 477 ORDER BY `created_at` DESC LIMIT 3\G

# Query 7: 456.85 QPS, 0.10x concurrency, ID 0x422390B42D4DD86C7539A5F45EB76A80 at byte 35242866
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:34
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          6   28325
# Exec time      5      6s    48us    18ms   223us   761us   543us    93us
# Lock time     19    71ms       0     4ms     2us     1us    42us     1us
# Rows sent      1  27.66k       1       1       1       1       0       1
# Rows examine   0  96.24k       0      23    3.48   12.54    4.98       0
# Query size     2   1.77M      62      66   65.65   65.89    1.48   65.89
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  ############################################
#   1ms  ####
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9803\G

# Query 8: 3.33 QPS, 0.09x concurrency, ID 0xE83DA93257C7B787C67B1B05D2469241 at byte 120384907
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.01
# Time range: 2023-11-02T10:37:32 to 2023-11-02T10:38:32
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     200
# Exec time      4      5s     8ms    68ms    26ms    46ms    12ms    23ms
# Lock time      0   327us       0    62us     1us     1us     4us     1us
# Rows sent      0   2.00k       2      18   10.24   14.52    2.88    9.83
# Rows examine   7   1.92M   9.77k   9.87k   9.82k   9.80k   48.50   9.80k
# Query size     0  22.25k     113     114  113.92  112.70       0  112.70
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 939 ORDER BY `created_at` DESC\G

# Query 9: 1.37 QPS, 0.07x concurrency, ID 0x009A61E5EFBD5A5E4097914B4DBD1C07 at byte 42548990
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.03
# Time range: 2023-11-02T10:37:33 to 2023-11-02T10:38:33
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0      82
# Exec time      3      4s     8ms   196ms    52ms   122ms    42ms    28ms
# Lock time      0   127us     1us     3us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    63  43.23M  75.38k   1.26M 539.87k   1.14M 464.48k 136.54k
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ####
#  10ms  ################################################################
# 100ms  ################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
INSERT INTO `posts` (`user_id`, `mime`, `imgdata`, `body`) VALUES (657,'image/png','�PNG\r\n\Z\n\0\0\0\rIHDR\0\0\0\0\0\\0\0\05؂Z\0\0\0gAMA\0\0��
# Query 10: 3.50 QPS, 0.03x concurrency, ID 0xC9383ACA6FF14C29E819735F00B6DBDF at byte 6767393
# Scores: V/M = 0.00
# Time range: 2023-11-02T10:49:19 to 2023-11-02T10:50:19
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     210
# Exec time      1      2s     3ms    43ms     9ms    21ms     6ms     6ms
# Lock time      1     5ms       0     3ms    24us     1us   231us     1us
# Rows sent      0   2.08k       4      19   10.12   14.52    2.82    9.83
# Rows examine   7   2.01M   9.77k   9.86k   9.81k   9.80k      46   9.80k
# Query size     0   9.41k      45      46   45.90   44.60    0.00   44.60
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  ###############################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `id` FROM `posts` WHERE `user_id` = 227\G
```



