### PR TITLE
4回目　プリアドステートメントの無効化

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -6,7 +6,7 @@ set -e
 echo
 echo '## alp'
 echo '```'
-sudo alp json --file /var/log/nginx/access.log -m "/image/[0-9a-zA-Z]+,/posts/[0-9a-zA-Z]+" --sort avg -r
+sudo alp json --file /var/log/nginx/access.log -m "/image/[0-9a-zA-Z]+,/posts/[0-9a-zA-Z]+,/@[0-9a-zA-Z]+" --sort avg -r
 echo '```'
 
 # pt-query-digest で解析

--- a/golang/app.go
+++ b/golang/app.go
@@ -47,6 +47,7 @@ type User struct {
 type Post struct {
 	ID           int       `db:"id"`
 	UserID       int       `db:"user_id"`
+	AccountName  string    `db:"account_name"`
 	Imgdata      []byte    `db:"imgdata"`
 	Body         string    `db:"body"`
 	Mime         string    `db:"mime"`
@@ -386,7 +387,7 @@ func getIndex(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err := db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC")
+	err := db.Select(&results, "SELECT p.id, p.user_id, p.body, p.created_at, p.mime, u.account_name FROM `posts` AS p JOIN `users` AS u ON (p.user_id=u.id) WHERE u.del_flg=0 ORDER BY p.created_at DESC LIMIT 20")
 	if err != nil {
 		log.Print(err)
 		return

--- a/golang/app.go
+++ b/golang/app.go
@@ -816,7 +816,7 @@ func main() {
 	}
 
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local",
+		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&interpolateParams=true&loc=Local",
 		user,
 		password,
 		host,

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,6 +69,18 @@ http {
 
         include /etc/nginx/conf.d/*.conf;
         include /etc/nginx/sites-enabled/*;
+        server {
+                location /image/ {
+                        root /home/isucon/private_isu/webapp/public/;
+                        expires 1d;
+                        try_files $uri @app;
+                }
+
+                location @app {
+                        internal;
+                        proxy_pass http://localhost:8080;
+                }
+        }
 }
 
 


### PR DESCRIPTION
## score
```
{"pass":true,"score":31873,"success":30007,"fail":0,"messages":[]}
```

## top
```
top - 20:11:45 up 39 min,  1 user,  load average: 1.27, 0.30, 0.28
Tasks: 112 total,   5 running, 107 sleeping,   0 stopped,   0 zombie
%Cpu(s): 62.4 us, 28.4 sy,  0.0 ni,  0.0 id,  0.0 wa,  0.0 hi,  9.2 si,  0.0 st
MiB Mem :   3827.7 total,   1191.4 free,    806.4 used,   1829.9 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.   2778.6 avail Mem

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
  14500 mysql     20   0 1806788 641620  36992 S  82.0  16.4   0:14.43 mysqld
  14021 isucon    20   0 1234608  21200   7040 S  67.7   0.5   0:10.54 app
  14287 www-data  20   0   56428   6684   4224 S  22.3   0.2   0:03.06 nginx
  14286 www-data  20   0   56148   6452   4224 S   8.0   0.2   0:00.99 nginx
    375 memcache  20   0  413424   7552   3712 S   0.7   0.2   0:00.54 memcached
     13 root      20   0       0      0      0 S   0.3   0.0   0:00.38 ksoftirqd/0
     14 root      20   0       0      0      0 R   0.3   0.0   0:00.27 rcu_sched
     22 root      20   0       0      0      0 S   0.3   0.0   0:00.36 ksoftirqd/1
     74 root      20   0       0      0      0 S   0.3   0.0   0:00.44 jbd2/nvme0n1p1-8
      1 root      20   0  100828  11520   8320 S   0.0   0.3   0:02.86 systemd
      2 root      20   0       0      0      0 S   0.0   0.0   0:00.00 kthreadd
      3 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 rcu_gp
      4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 rcu_par_gp
      5 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 slub_flushwq
      6 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 netns
      7 root      20   0       0      0      0 I   0.0   0.0   0:00.04 kworker/0:0-events
      8 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker/0:0H-events_highpri
     10 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 mm_percpu_wq
     11 root      20   0       0      0      0 I   0.0   0.0   0:00.00 rcu_tasks_rude_kthread
```
## alp
```
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
| COUNT | 1XX |  2XX  | 3XX | 4XX | 5XX | METHOD |         URI         |  MIN  |  MAX  |   SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY) |  MAX(BODY)  |   SUM(BODY)    | AVG(BODY)  |
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
|   220 |   0 |   220 |   0 |   0 |   0 | GET    | /posts              | 0.056 | 0.528 |  72.140 | 0.328 | 0.420 | 0.440 | 0.508 |  0.088 |  4965.000 |    5785.000 |    1174457.000 |   5338.441 |
|   226 |   0 |   226 |   0 |   0 |   0 | GET    | /@[0-9a-zA-Z]+      | 0.040 | 0.476 |  61.752 | 0.273 | 0.368 | 0.404 | 0.440 |  0.073 |  1868.000 |    5314.000 |     750246.000 |   3319.673 |
|     1 |   0 |     1 |   0 |   0 |   0 | GET    | /initialize         | 0.240 | 0.240 |   0.240 | 0.240 | 0.240 | 0.240 | 0.240 |  0.000 |     0.000 |       0.000 |          0.000 |      0.000 |
|  1114 |   0 |  1114 |   0 |   0 |   0 | GET    | /                   | 0.016 | 0.352 | 168.124 | 0.151 | 0.216 | 0.236 | 0.268 |  0.049 |  2610.000 |    6043.000 |    3486645.000 |   3129.843 |
|   128 |   0 |     0 | 128 |   0 |   0 | POST   | /register           | 0.012 | 0.164 |   9.784 | 0.076 | 0.124 | 0.136 | 0.164 |  0.032 |     0.000 |       0.000 |          0.000 |      0.000 |
|   206 |   0 |     0 | 103 | 103 |   0 | POST   | /                   | 0.008 | 0.260 |  12.096 | 0.059 | 0.164 | 0.192 | 0.232 |  0.065 |     0.000 |       0.000 |          0.000 |      0.000 |
|   804 |   0 |     0 | 804 |   0 |   0 | POST   | /login              | 0.004 | 0.180 |  44.232 | 0.055 | 0.100 | 0.112 | 0.140 |  0.033 |     0.000 |       0.000 |          0.000 |      0.000 |
|  1433 |   0 |  1433 |   0 |   0 |   0 | GET    | /posts/[0-9a-zA-Z]+ | 0.004 | 0.176 |  52.772 | 0.037 | 0.068 | 0.080 | 0.104 |  0.021 |   735.000 |    1981.000 |    1842737.000 |   1285.930 |
|   110 |   0 |     0 | 110 |   0 |   0 | POST   | /comment            | 0.004 | 0.072 |   2.560 | 0.023 | 0.040 | 0.044 | 0.060 |  0.012 |     0.000 |       0.000 |          0.000 |      0.000 |
| 17783 |   0 | 17783 |   0 |   0 |   0 | GET    | /image/[0-9a-zA-Z]+ | 0.000 | 0.220 | 188.436 | 0.011 | 0.024 | 0.028 | 0.048 |  0.010 | 36588.000 | 1253029.000 | 6219886292.000 | 349765.860 |
|   128 |   0 |     0 |   0 | 128 |   0 | GET    | /admin/banned       | 0.004 | 0.048 |   1.348 | 0.011 | 0.024 | 0.032 | 0.040 |  0.010 |     0.000 |       0.000 |          0.000 |      0.000 |
|   240 |   0 |   240 |   0 |   0 |   0 | GET    | /login              | 0.000 | 0.036 |   1.172 | 0.005 | 0.012 | 0.016 | 0.028 |  0.006 |   615.000 |     615.000 |     147600.000 |    615.000 |
|   120 |   0 |     0 | 120 |   0 |   0 | GET    | /logout             | 0.008 | 0.036 |   0.464 | 0.004 | 0.008 | 0.012 | 0.028 |  0.005 |    24.000 |      24.000 |       2880.000 |     24.000 |
|  1878 |   0 |  1878 |   0 |   0 |   0 | GET    | /favicon.ico        | 0.000 | 0.044 |   5.128 | 0.003 | 0.008 | 0.012 | 0.020 |  0.005 |    43.000 |      43.000 |      80754.000 |     43.000 |
|  1878 |   0 |  1878 |   0 |   0 |   0 | GET    | /js/timeago.min.js  | 0.000 | 0.036 |   4.648 | 0.002 | 0.008 | 0.008 | 0.016 |  0.004 |  1915.000 |    1915.000 |    3596370.000 |   1915.000 |
|  1878 |   0 |  1878 |   0 |   0 |   0 | GET    | /js/main.js         | 0.000 | 0.048 |   4.236 | 0.002 | 0.008 | 0.008 | 0.020 |  0.004 |  1824.000 |    1824.000 |    3425472.000 |   1824.000 |
|  1878 |   0 |  1878 |   0 |   0 |   0 | GET    | /css/style.css      | 0.000 | 0.056 |   4.020 | 0.002 | 0.008 | 0.008 | 0.016 |  0.004 |  1549.000 |    1549.000 |    2909022.000 |   1549.000 |
+-------+-----+-------+-----+-----+-----+--------+---------------------+-------+-------+---------+-------+-------+-------+-------+--------+-----------+-------------+----------------+------------+
```
## pt-query-digest
```

# 11.1s user time, 70ms system time, 44.34M rss, 50.29M vsz
# Current date: Thu Nov  2 20:13:25 2023
# Hostname: ip-192-168-1-10
# Files: /var/log/mysql/mysql-slow.log
# Overall: 174.85k total, 27 unique, 2.36k QPS, 1.36x concurrency ________
# Time range: 2023-11-02T11:11:17 to 2023-11-02T11:12:31
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time           101s     1us   211ms   576us     1ms     5ms   108us
# Lock time          422ms       0    18ms     2us     1us    73us     1us
# Rows sent          2.26M       0   9.75k   13.55    2.90  338.63    0.99
# Rows examine      28.37M       0  97.76k  170.14   12.54   3.53k    0.99
# Query size        62.82M      10   1.14M  376.73   80.10  15.99k   36.69

# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0x19759A5557089FD5B718D440... 17.6908 17.5% 19216 0.0009  0.00 SELECT posts
#    2 0xCDEB1AFF2AE2BE51B2ED5CF0... 16.9792 16.8%   226 0.0751  0.01 SELECT comments
#    3 0x396201721CD58410E070DA94... 15.8512 15.7% 73183 0.0002  0.00 SELECT users
#    4 0x7A12D0C8F433684C3027353C... 15.2305 15.1%   220 0.0692  0.01 SELECT posts
#    5 0x624863D30DAC59FA16849282...  8.8246  8.8% 29159 0.0003  0.00 SELECT comments
#    6 0x422390B42D4DD86C7539A5F4...  7.8137  7.8% 30592 0.0003  0.00 SELECT comments
#    7 0x2822B8A98D614ECBDD1C1E56...  6.5158  6.5%   101 0.0645  0.03 INSERT posts
#    8 0xE83DA93257C7B787C67B1B05...  5.0976  5.1%   226 0.0226  0.01 SELECT posts
#    9 0xC9383ACA6FF14C29E819735F...  2.0257  2.0%   226 0.0090  0.01 SELECT posts
# MISC 0xMISC                         4.7890  4.8% 21701 0.0002   0.0 <18 ITEMS>

# Query 1: 309.94 QPS, 0.29x concurrency, ID 0x19759A5557089FD5B718D440CBBB5C55 at byte 1894612
# Scores: V/M = 0.00
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         10   19216
# Exec time     17     18s    98us   146ms   920us     4ms     2ms   273us
# Lock time     14    63ms       0     9ms     3us     1us    91us     1us
# Rows sent      0  18.77k       1       1       1       1       0       1
# Rows examine   0  18.77k       1       1       1       1       0       1
# Query size     1 741.10k      36      40   39.49   38.53    0.25   38.53
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  #
# 100us  ################################################################
#   1ms  #################
#  10ms  #
# 100ms  #
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `posts` WHERE `id` = 8847\G

# Query 2: 3.70 QPS, 0.28x concurrency, ID 0xCDEB1AFF2AE2BE51B2ED5CF03D4E749F at byte 30808630
# Scores: V/M = 0.01
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:30
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     226
# Exec time     16     17s    15ms   182ms    75ms   128ms    31ms    65ms
# Lock time      0   299us       0    23us     1us     1us     1us     1us
# Rows sent      0     226       1       1       1       1       0       1
# Rows examine  76  21.56M  97.66k  97.76k  97.71k  97.04k       0  97.04k
# Query size     0  13.67k      61      62   61.92   59.77       0   59.77
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms  ###################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 781\G

# Query 3: 1.18k QPS, 0.26x concurrency, ID 0x396201721CD58410E070DA9421CA8C8D at byte 40169228
# Scores: V/M = 0.00
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         41   73183
# Exec time     15     16s    39us    20ms   216us   657us   596us    89us
# Lock time     51   218ms       0    18ms     2us     1us    95us     1us
# Rows sent      3  71.47k       1       1       1       1       0       1
# Rows examine   0  71.47k       1       1       1       1       0       1
# Query size     4   2.64M      36      39   37.88   36.69    0.17   36.69
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  #########################################
#   1ms  ###
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'users'\G
#    SHOW CREATE TABLE `isuconp`.`users`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `users` WHERE `id` = 200\G

# Query 4: 3.61 QPS, 0.25x concurrency, ID 0x7A12D0C8F433684C3027353C36CAB572 at byte 30813699
# Scores: V/M = 0.01
# Time range: 2023-11-02T11:11:30 to 2023-11-02T11:12:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     220
# Exec time     15     15s    33ms   185ms    69ms   116ms    25ms    65ms
# Lock time      0   295us       0     9us     1us     1us       0     1us
# Rows sent     91   2.08M   9.57k   9.75k   9.66k   9.33k       0   9.33k
# Rows examine   7   2.08M   9.57k   9.75k   9.66k   9.33k       0   9.33k
# Query size     0  30.51k     142     142     142     142       0     142
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms  ##########
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= '2016-01-02T11:43:26+09:00' ORDER BY `created_at` DESC\G

# Query 5: 470.31 QPS, 0.14x concurrency, ID 0x624863D30DAC59FA16849282195BE09F at byte 38793869
# Scores: V/M = 0.00
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         16   29159
# Exec time      8      9s    71us    17ms   302us     1ms   694us   131us
# Lock time     12    55ms       0     4ms     1us     1us    30us     1us
# Rows sent      1  27.25k       0       3    0.96    2.90    1.35       0
# Rows examine   0 117.19k       0      26    4.12   15.25    6.13       0
# Query size     3   2.30M      79      83   82.68   80.10    0.10   80.10
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ######
# 100us  ################################################################
#   1ms  ###
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `comments` WHERE `post_id` = 10485 ORDER BY `created_at` DESC LIMIT 3\G

# Query 6: 493.42 QPS, 0.13x concurrency, ID 0x422390B42D4DD86C7539A5F45EB76A80 at byte 20975730
# Scores: V/M = 0.00
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:31
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         17   30592
# Exec time      7      8s    63us    16ms   255us   799us   620us   119us
# Lock time     17    76ms       0     5ms     2us     1us    54us     1us
# Rows sent      1  29.88k       1       1       1       1       0       1
# Rows examine   0 102.86k       0      23    3.44   12.54    4.98       0
# Query size     3   1.92M      62      66   65.65   65.89    1.49   65.89
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us  ############
# 100us  ################################################################
#   1ms  ###
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10475\G

# Query 7: 1.68 QPS, 0.11x concurrency, ID 0x2822B8A98D614ECBDD1C1E56F2EB7F75 at byte 27139119
# Scores: V/M = 0.03
# Time range: 2023-11-02T11:11:29 to 2023-11-02T11:12:29
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     101
# Exec time      6      7s     8ms   186ms    65ms   141ms    47ms    65ms
# Lock time      0   160us     1us     3us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    83  52.64M  61.05k   1.14M 533.65k 1009.33k 396.02k 753.18k
# String:
# Databases    isuconp
# Hosts        localhost
# Users        isuconp
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #
#  10ms  ################################################################
# 100ms  #############################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
INSERT INTO `posts` (`user_id`, `mime`, `imgdata`, `body`) VALUES (381,'image/png',_binary'�PNG\r\n\Z\n\0\0\0\rIHDR\0\0\0\0\0\\0\0\05؂Z\0\0\0gAMA\0\0��
```